### PR TITLE
Do not create NSDate with incorrect 0 value

### DIFF
--- a/AppHub.podspec
+++ b/AppHub.podspec
@@ -1,0 +1,45 @@
+#
+# Be sure to run `pod lib lint AppHub.podspec' to ensure this is a
+# valid spec before submitting.
+#
+# Any lines starting with a # are optional, but their use is encouraged
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
+#
+
+Pod::Spec.new do |s|
+  s.name             = "AppHub"
+  s.version          = "0.2.2"
+  s.summary          = "This is the iOS client for AppHub: https://apphub.io"
+
+# This description is used to generate tags and improve search results.
+#   * Think: What does it do? Why did you write it? What is the focus?
+#   * Try to keep it short, snappy and to the point.
+#   * Write the description between the DESC delimiters below.
+#   * Finally, don't worry about the indent, CocoaPods strips it!
+  s.description      = <<-DESC
+  AppHub lets you instantly update React Native apps without resubmitting to the App Store.
+                       DESC
+
+  s.homepage         = "https://github.com/AppHubPlatform/apphub-ios"
+  s.license          = 'MIT'
+  s.author           = { "Matthew Arbesfeld" => "support@apphub.com" }
+  s.source           = { :git => "https://github.com/AppHubPlatform/apphub-ios.git", :tag => s.version.to_s }
+  s.social_media_url = 'https://twitter.com/AppHubPlatform'
+
+  s.platform     = :ios, '7.0'
+  s.requires_arc = true
+
+  s.exclude_files = 'AppHub/AppHub/React/**/*'
+  s.source_files = [
+    'AppHub/AppHub/**/*.{h,m,c}'
+  ]
+  s.public_header_files = [
+    'AppHub/AppHub/AHBuildManager.h',
+    'AppHub/AppHub/AppHub.h',
+    'AppHub/AppHub/AHBuild.h',
+    'AppHub/AppHub/AHDefines.h',
+  ]
+  s.libraries = 'z'
+  s.frameworks = 'SystemConfiguration'
+  s.dependency 'React'
+end

--- a/AppHub/AppHub/AHBuild.h
+++ b/AppHub/AppHub/AHBuild.h
@@ -20,6 +20,8 @@ Example usage:
 
  */
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface AHBuild : NSObject
 
 ///---------------------
@@ -49,9 +51,11 @@ Example usage:
 @property (nonatomic, readonly) NSString *buildDescription;
 
 /// The date at which the build was created.
-@property (nonatomic, readonly) NSDate *creationDate;
+@property (nullable, nonatomic, readonly) NSDate *creationDate;
 
 /// An array of iOS app version strings with which the build is compatible.
 @property (nonatomic, readonly) NSArray *compatibleIOSVersions;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/AppHub/AppHub/AHBuild.m
+++ b/AppHub/AppHub/AHBuild.m
@@ -38,11 +38,12 @@ NS_INLINE NSString *AHShortVersionString(void)
         _buildDescription = [info[AHBuildDataDescriptionKey] copy] ?: @"This build was downloaded from the App Store.";
         _bundle = bundle ?: [NSBundle mainBundle];
         _compatibleIOSVersions = [info[AHBuildDataCompatibleIOSVersionsKey] allValues] ?: @[AHShortVersionString()];
-        _creationDate = [NSDate dateWithTimeIntervalSince1970:[info[AHBuildDataCreatedAtKey] doubleValue] / 1000.0];
+        if (info[AHBuildDataCreatedAtKey]) {
+            _creationDate = [NSDate dateWithTimeIntervalSince1970:[info[AHBuildDataCreatedAtKey] doubleValue] / 1000.0];
+        }
         _identifier = [info[AHBuildDataBuildIDKey] copy] ?: AHDefaultBuildID;
         _name = [info[AHBuildDataNameKey] copy] ?: AHDefaultBuildID;
     }
-    
     return self;
 }
 
@@ -62,7 +63,7 @@ NS_INLINE NSString *AHShortVersionString(void)
         AHExportedBuildDataBuildIDKey: _identifier,
         AHExportedBuildDataNameKey: _name,
         AHExportedBuildDataDescriptionKey: _buildDescription,
-        AHExportedBuildDataCreatedAtKey: @(_creationDate.timeIntervalSince1970 * 1000.0),
+        AHExportedBuildDataCreatedAtKey: _creationDate ? @(_creationDate.timeIntervalSince1970 * 1000.0) : [NSNull null],
         AHExportedBuildDataCompatibleIOSVersionsKey: _compatibleIOSVersions,
     };
 }

--- a/AppHub/AppHub/AHBuild.m
+++ b/AppHub/AppHub/AHBuild.m
@@ -37,7 +37,7 @@ NS_INLINE NSString *AHShortVersionString(void)
     if ((self = [super init])) {
         _buildDescription = [info[AHBuildDataDescriptionKey] copy] ?: @"This build was downloaded from the App Store.";
         _bundle = bundle ?: [NSBundle mainBundle];
-        _compatibleIOSVersions = info[AHBuildDataCompatibleIOSVersionsKey] ?: AHShortVersionString();
+        _compatibleIOSVersions = [info[AHBuildDataCompatibleIOSVersionsKey] allValues] ?: @[AHShortVersionString()];
         _creationDate = [NSDate dateWithTimeIntervalSince1970:[info[AHBuildDataCreatedAtKey] doubleValue] / 1000.0];
         _identifier = [info[AHBuildDataBuildIDKey] copy] ?: AHDefaultBuildID;
         _name = [info[AHBuildDataNameKey] copy] ?: AHDefaultBuildID;

--- a/AppHub/AppHubTests/AHBuildTests.m
+++ b/AppHub/AppHubTests/AHBuildTests.m
@@ -30,7 +30,7 @@
         XCTAssertNotNil(build.name);
         XCTAssertNotNil(build.buildDescription);
         XCTAssertNotNil(build.compatibleIOSVersions);
-        XCTAssertNotNil(build.creationDate);
+        XCTAssertNil(build.creationDate);
         XCTAssertEqualObjects(build.identifier, @"LOCAL");
         XCTAssertEqualObjects(build.bundle, [NSBundle mainBundle]);
     }

--- a/AppHub/AppHubTests/AppHubTests.m
+++ b/AppHub/AppHubTests/AppHubTests.m
@@ -67,7 +67,7 @@
         XCTAssertEqualObjects(result.identifier, dict[AHBuildDataBuildIDKey]);
         XCTAssertEqualObjects(result.name, dict[AHBuildDataNameKey]);
         XCTAssertEqualObjects(result.buildDescription, dict[AHBuildDataDescriptionKey]);
-        XCTAssertEqualObjects(result.compatibleIOSVersions, dict[AHBuildDataCompatibleIOSVersionsKey]);
+        XCTAssertEqualObjects(result.compatibleIOSVersions, [dict[AHBuildDataCompatibleIOSVersionsKey] allValues]);
         
         NSTimeInterval creationDate = [result.creationDate timeIntervalSince1970];
         NSTimeInterval createdSeconds = [dict[AHBuildDataCreatedAtKey] doubleValue] / 1000;

--- a/AppHubIntegration/AppHubIntegrationTests/AppHubIntegrationTests.m
+++ b/AppHubIntegration/AppHubIntegrationTests/AppHubIntegrationTests.m
@@ -65,7 +65,7 @@ static XCTestExpectation *_newBuildExpectation;
     [[NSRunLoop mainRunLoop] runMode:NSRunLoopCommonModes beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
     
     foundElement = [self findSubviewInView:vc.view matching:^BOOL(UIView *view) {
-      if ([view.accessibilityLabel isEqualToString:@"buildIdentifier:LOCALbuildName:LOCALbuildDescription:This build was downloaded from the App Store.buildCreatedAt:0buildCompatibleIOSVersions:1.0"]) {
+      if ([view.accessibilityLabel isEqualToString:@"buildIdentifier:LOCALbuildName:LOCALbuildDescription:This build was downloaded from the App Store.buildCreatedAt:buildCompatibleIOSVersions:1.0"]) {
         return YES;
       }
       return NO;


### PR DESCRIPTION
Not sure about this, but just an idea. Creating NSDate with a `timeIntervalSince1970 = 0` is misleading, especially in Swift. If it does not exist we should use nil as the default value. 
