### PR TITLE
Fixe missing platform argument

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -44,6 +44,7 @@ var argv = require('yargs')
       '--dev', argv.dev,
       '--bundle-output', path.join(buildDir, argv.outputFile),
       '--assets-dest', buildDir,
+      '--platform', 'ios',
     ];
 
     var cmds = [

--- a/cli/index.js
+++ b/cli/index.js
@@ -29,6 +29,10 @@ var argv = require('yargs')
         default: false,
         description: 'If false, warnings are disabled and the bundle is minified'
       })
+      .option('platform',  {
+        default: 'ios',
+        description: 'Either "ios" or "android"'
+      })
       .help('help')
       .argv
 
@@ -44,7 +48,7 @@ var argv = require('yargs')
       '--dev', argv.dev,
       '--bundle-output', path.join(buildDir, argv.outputFile),
       '--assets-dest', buildDir,
-      '--platform', 'ios',
+      '--platform', argv.platform,
     ];
 
     var cmds = [


### PR DESCRIPTION
react-native cli (0.1.7) need the platform argument in order to build.
