### PR TITLE
Task handler block

### DIFF
--- a/AppHub/AppHub/AHBuildManager.h
+++ b/AppHub/AppHub/AHBuildManager.h
@@ -9,6 +9,8 @@
 
 #import "AHDefines.h"
 
+typedef void (^TaskHandlerBlock)(NSURLSessionDownloadTask *task);
+
 @class AHBuild;
 
 /**
@@ -94,5 +96,16 @@ extern NSString *const AHBuildManagerBuildKey;
  * be the most up-to-date build of your application.
  */
 - (void)fetchBuildWithCompletionHandler:(AHBuildResultBlock)completionHandler;
+
+/**
+ * Hook called after NSURLSessionDownloadTask has created
+ *
+ * Useful for a handling download progress on the slow connection:
+ *
+ * [[AppHub buildManager] setTaskHandlerBlock:^(NSURLSessionDownloadTask *task){
+ *   [progressView setProgressWithDownloadProgressOfTask:task animated:YES];
+ * }];
+ */
+@property (nonatomic, copy) TaskHandlerBlock taskHandlerBlock;
 
 @end

--- a/AppHub/AppHub/AHBuildManager.m
+++ b/AppHub/AppHub/AHBuildManager.m
@@ -173,6 +173,9 @@ NSString *const AHBuildManagerBuildKey = @"AHNewBuildKey";
             completion(nil, AHError(@"Build does not contain bundle at path: %@", bundleDirectory.path));
         }
     }];
+    if (self.taskHandlerBlock) {
+        self.taskHandlerBlock(task);
+    }
     [task resume];
 }
 


### PR DESCRIPTION
I have the use case when the build is being forced to download on the start-up time, even on slow connections. It would useful to show a UIProgressView at that time.

This PR adds a special hook to AHBuildManager.

My AppDelegate is something like this:

UIProgressView *progressView = (UIProgressView *)[_launchView subviews].lastObject;
[[AppHub buildManager] setTaskHandlerBlock:^(NSURLSessionDownloadTask *task){
     [progressView setProgressWithDownloadProgressOfTask:task animated:YES];
}];

_Sorry for not squashed commits._
