### PR TITLE
Updated cli to use local-cli/cli.js rather than react-native-cli

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -49,7 +49,7 @@ var argv = require('yargs')
     ];
 
     var cmds = [
-      'react-native bundle ' + options.join(' '),
+      'node node_modules/react-native/local-cli/cli.js bundle ' + options.join(' '),
       'cp ' + plistFile + ' ' + buildDir,
       'cd ' + tmpDir + ' && zip -r ' + outputZip + ' ' + BUILD_DIR_NAME,
     ];


### PR DESCRIPTION
I kept running into this error: https://github.com/facebook/react-native/issues/4515

apphub currently requires you to have react-native-cli installed globally, which doesn't seem necessary.

`react-native init` now references `node node_modules/react-native/local-cli/cli.js start` instead of `react-native start`
