### PR TITLE
Share bundle between app and extension

### DIFF
--- a/AppHub/AppHub/AHBuildManager.h
+++ b/AppHub/AppHub/AHBuildManager.h
@@ -97,6 +97,8 @@ extern NSString *const AHBuildManagerBuildKey;
  */
 - (void)fetchBuildWithCompletionHandler:(AHBuildResultBlock)completionHandler;
 
+- (AHBuild *)currentBuildForGroupIdentifier:(NSString *)groupIdentifier;
+
 /**
  * Hook called after NSURLSessionDownloadTask has created
  *

--- a/AppHub/AppHub/AHBuildManager.m
+++ b/AppHub/AppHub/AHBuildManager.m
@@ -79,6 +79,12 @@ NSString *const AHBuildManagerBuildKey = @"AHNewBuildKey";
     return [NSDictionary dictionaryWithContentsOfURL:AHCurrentBuildInfoDirectory()];
 }
 
+- (AHBuild *)currentBuildForGroupIdentifier:(NSString *)groupIdentifier {
+    ahGroupIdentifier = groupIdentifier;
+    
+    return [self currentBuild];
+}
+
 - (AHBuild *)currentBuild
 {
     NSDictionary *currentBuildInfo = [self currentBuildInfo];

--- a/AppHub/AppHub/AHPaths.h
+++ b/AppHub/AppHub/AHPaths.h
@@ -13,5 +13,4 @@ extern NSURL *AHCurrentBuildInfoDirectory(void);
 extern NSURL *AHBuildsDirectory(void);
 extern NSURL *AHRootDirectory(void);
 
-NSString *ahGroupIdentifier = nil;
-
+extern NSString *ahGroupIdentifier;

--- a/AppHub/AppHub/AHPaths.h
+++ b/AppHub/AppHub/AHPaths.h
@@ -12,3 +12,6 @@ extern NSURL *AHBundleDirectory(NSString *buildID);
 extern NSURL *AHCurrentBuildInfoDirectory(void);
 extern NSURL *AHBuildsDirectory(void);
 extern NSURL *AHRootDirectory(void);
+
+NSString *ahGroupIdentifier = nil;
+

--- a/AppHub/AppHub/AHPaths.m
+++ b/AppHub/AppHub/AHPaths.m
@@ -31,5 +31,9 @@ NSURL *AHBuildsDirectory(void)
 
 NSURL *AHRootDirectory(void)
 {
-    return [[[[NSFileManager defaultManager] URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask] lastObject] URLByAppendingPathComponent:AHDirectoryName isDirectory:YES];
+    if(ahGroupIdentifier == nil) {
+        return [[[[NSFileManager defaultManager] URLsForDirectory:NSApplicationSupportDirectory inDomains:NSUserDomainMask] lastObject] URLByAppendingPathComponent:AHDirectoryName isDirectory:YES];
+    } else {
+        return [[[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:ahGroupIdentifier] URLByAppendingPathComponent: AHDirectoryName isDirectory:YES];
+    }
 }

--- a/AppHub/AppHub/AHPaths.m
+++ b/AppHub/AppHub/AHPaths.m
@@ -9,6 +9,8 @@
 
 #import "AHConstants.h"
 
+NSString *ahGroupIdentifier = nil;
+
 NSURL *AHBuildDirectory(NSString *buildID)
 {
     return [AHBuildsDirectory() URLByAppendingPathComponent:buildID isDirectory:YES];


### PR DESCRIPTION
This allows the code to be installed in a directory based on the `ahGroupIdentifier` which enables the bundle to be shared between app + extension
