### PR TITLE
Use React/Core for the podspec dependency

### DIFF
--- a/AppHub.podspec
+++ b/AppHub.podspec
@@ -41,5 +41,5 @@ Pod::Spec.new do |s|
   ]
   s.libraries = 'z'
   s.frameworks = 'SystemConfiguration'
-  s.dependency 'React'
+  s.dependency 'React/Core'
 end


### PR DESCRIPTION
Hey there! Nice library, looking 👍 so far :)

So, you have a dependency on `React` however, the only headers that you use are these:

![screen shot 2016-09-05 at 3 10 00 pm](https://cloud.githubusercontent.com/assets/49038/18255772/01288cf0-737b-11e6-9d17-f05512ec4740.png)

Which are all available in just `React/Core` ( this is a [CocoaPods subspec](https://guides.cocoapods.org/syntax/podspec.html#subspec) feature the allows you to reduce your dependency tree )

![screen shot 2016-09-05 at 3 11 45 pm](https://cloud.githubusercontent.com/assets/49038/18255807/55e3c78c-737b-11e6-9cab-e428c775da5e.png)
