### PR TITLE
Allow consumers to specify a version for using with AppHub

### DIFF
--- a/AppHub/AppHub/AHBuildManager+Private.h
+++ b/AppHub/AppHub/AHBuildManager+Private.h
@@ -10,8 +10,6 @@
 @interface AHBuildManager ()
 
 @property (nonatomic, getter=isFetchingBuild) BOOL fetchingBuild;
-/// Defaults to NSBundle mainBundle's CFBundleShortVersionString
-@property (nonatomic, copy, readwrite) NSString *installedAppVersion;
 @property (nonatomic, readonly, strong) NSMutableString *logs;
 @property (nonatomic, strong) NSTimer *pollingTimer;
 @property (nonatomic, strong) NSMutableArray *completionHandlers;

--- a/AppHub/AppHub/AHBuildManager+Private.h
+++ b/AppHub/AppHub/AHBuildManager+Private.h
@@ -10,7 +10,8 @@
 @interface AHBuildManager ()
 
 @property (nonatomic, getter=isFetchingBuild) BOOL fetchingBuild;
-@property (nonatomic, copy, readonly) NSString *installedAppVersion;
+/// Defaults to NSBundle mainBundle's CFBundleShortVersionString
+@property (nonatomic, copy, readwrite) NSString *installedAppVersion;
 @property (nonatomic, readonly, strong) NSMutableString *logs;
 @property (nonatomic, strong) NSTimer *pollingTimer;
 @property (nonatomic, strong) NSMutableArray *completionHandlers;

--- a/AppHub/AppHub/AHBuildManager.h
+++ b/AppHub/AppHub/AHBuildManager.h
@@ -82,6 +82,16 @@ extern NSString *const AHBuildManagerBuildKey;
  */
 @property (nonatomic, assign, getter=areCellularDownloadsEnabled) BOOL cellularDownloadsEnabled;
 
+
+/**
+ * By default, the AppHub SDK will use the version of your application to ensure that AppHub builds match
+ * your application. If the version of your AppHub build is different to your application's then
+ * you can use this setting to have AppHub look for a specific version.
+ *
+ * Defaults to `NSBundle mainBundle`'s CFBundleShortVersionString.
+ */
+@property (nonatomic, copy, readwrite) NSString *installedAppVersion;
+
 ///---------------------
 /// @name Fetching Builds Manually (Advanced)
 ///---------------------

--- a/AppHub/AppHub/AHBuildManager.m
+++ b/AppHub/AppHub/AHBuildManager.m
@@ -56,6 +56,8 @@ NSString *const AHBuildManagerBuildKey = @"AHNewBuildKey";
 
 - (NSString *)installedAppVersion
 {
+    if (_installedAppVersion) { return _installedAppVersion; }
+
     NSBundle *mainBundle = [NSBundle mainBundle];
     return mainBundle.infoDictionary[@"CFBundleShortVersionString"];
 }


### PR DESCRIPTION
In our app we have a [separate library](http://artsy.github.io/blog/2016/08/24/On-Emission/) that contains all our React Native code - this means it's version is completely out of sync with  the actual app itself, this PR gives the consuming the ability to set the version 👍 

re: https://github.com/artsy/eigen/pull/1817 
