### PR TITLE
Improve the Build List UI

### DIFF
--- a/AppHub/AppHub/AHBuildManager+Private.h
+++ b/AppHub/AppHub/AHBuildManager+Private.h
@@ -10,8 +10,6 @@
 @interface AHBuildManager ()
 
 @property (nonatomic, getter=isFetchingBuild) BOOL fetchingBuild;
-/// Defaults to NSBundle mainBundle's CFBundleShortVersionString
-@property (nonatomic, copy, readwrite) NSString *installedAppVersion;
 @property (nonatomic, readonly, strong) NSMutableString *logs;
 @property (nonatomic, strong) NSTimer *pollingTimer;
 @property (nonatomic, strong) NSMutableArray *completionHandlers;

--- a/AppHub/AppHub/AHBuildManager+Private.h
+++ b/AppHub/AppHub/AHBuildManager+Private.h
@@ -10,7 +10,8 @@
 @interface AHBuildManager ()
 
 @property (nonatomic, getter=isFetchingBuild) BOOL fetchingBuild;
-@property (nonatomic, copy, readonly) NSString *installedAppVersion;
+/// Defaults to NSBundle mainBundle's CFBundleShortVersionString
+@property (nonatomic, copy, readwrite) NSString *installedAppVersion;
 @property (nonatomic, readonly, strong) NSMutableString *logs;
 @property (nonatomic, strong) NSTimer *pollingTimer;
 @property (nonatomic, strong) NSMutableArray *completionHandlers;

--- a/AppHub/AppHub/AHBuildManager.h
+++ b/AppHub/AppHub/AHBuildManager.h
@@ -82,6 +82,16 @@ extern NSString *const AHBuildManagerBuildKey;
  */
 @property (nonatomic, assign, getter=areCellularDownloadsEnabled) BOOL cellularDownloadsEnabled;
 
+
+/**
+ * By default, the AppHub SDK will use the version of your application to ensure that AppHub builds match
+ * your application. If the version of your AppHub build is different to your application's then
+ * you can use this setting to have AppHub look for a specific version.
+ *
+ * Defaults to `NSBundle mainBundle`'s CFBundleShortVersionString.
+ */
+@property (nonatomic, copy, readwrite) NSString *installedAppVersion;
+
 ///---------------------
 /// @name Fetching Builds Manually (Advanced)
 ///---------------------

--- a/AppHub/AppHub/AHBuildManager.m
+++ b/AppHub/AppHub/AHBuildManager.m
@@ -56,6 +56,8 @@ NSString *const AHBuildManagerBuildKey = @"AHNewBuildKey";
 
 - (NSString *)installedAppVersion
 {
+    if (_installedAppVersion) { return _installedAppVersion; }
+
     NSBundle *mainBundle = [NSBundle mainBundle];
     return mainBundle.infoDictionary[@"CFBundleShortVersionString"];
 }

--- a/AppHub/AppHub/AHBuildsListViewController.h
+++ b/AppHub/AppHub/AHBuildsListViewController.h
@@ -11,6 +11,7 @@
 
 @interface AHBuildsListViewController : UITableViewController
 
+
 - (instancetype)initWithBuildsResultsHandler:(AHBuildResultBlock)block;
 
 @end


### PR DESCRIPTION
Includes #34 

Hey there, just wanted to add some polish to your build list view controller, mainly:
- Splits out the two local/remote
- Shows the app versions that a build works with
- Orders the builds

Before:
![screen shot 2016-09-14 at 9 41 41 am](https://cloud.githubusercontent.com/assets/49038/18515462/7af7b396-7a63-11e6-8c7b-994a5350418d.png)

After:

![screen shot 2016-09-14 at 10 08 32 am](https://cloud.githubusercontent.com/assets/49038/18515470/801bfc2e-7a63-11e6-81fc-d474c51bba0e.png)

![screen shot 2016-09-14 at 10 08 34 am](https://cloud.githubusercontent.com/assets/49038/18515473/81eaf5dc-7a63-11e6-8f6e-c6e3a046d47b.png)

Tests still pass:
![screen shot 2016-09-14 at 10 09 14 am](https://cloud.githubusercontent.com/assets/49038/18515457/6f984b3c-7a63-11e6-9dec-ee1e1d7adaae.png)

re: https://github.com/artsy/eigen/pull/1817
